### PR TITLE
chore: Updates virtualenv getting started commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,15 +40,15 @@ In order to use this library, you first need to go through the following steps:
 Installation
 ~~~~~~~~~~~~
 
-Install this library in a `virtualenv`_ using pip. `virtualenv`_ is a tool to
-create isolated Python environments. The basic problem it addresses is one of
+Install this library within a Python virtual environment using the `venv`_ module. `venv`_ is a tool to
+create isolated Python environments. The basic problem this addresses is one of
 dependencies and versions, and indirectly permissions.
 
-With `virtualenv`_, it's possible to install this library without needing system
+With `venv`_, it's possible to install this library without needing system
 install permissions, and without clashing with the installed system
 dependencies.
 
-.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
+.. _`venv`: https://docs.python.org/3/library/venv.html
 
 
 Mac/Linux

--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,9 @@ Mac/Linux
 
 .. code-block:: console
 
-    pip install virtualenv
-    virtualenv <your-env>
+    python3 -m venv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-artifact-registry
+    pip3 install google-cloud-artifact-registry
 
 
 Windows
@@ -67,10 +66,9 @@ Windows
 
 .. code-block:: console
 
-    pip install virtualenv
-    virtualenv <your-env>
+    python3 -m venv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-artifact-registry
+    pip3 install google-cloud-artifact-registry
 
 Next Steps
 ~~~~~~~~~~


### PR DESCRIPTION
`venv` is included in all versions of Python that the library supports - this small PR updates the getting started info in the README to use the builtin version of `venv` rather that requiring users to install the additional `virtualenv` package - the additional features of which are not used in the guide, or generally required (and system `pip` calls can cause issues if the user's permissions/path are not set correctly).

Also updates the `pip install` call to be relative, as after venv activation it should resolve to the venv's instance, making the path unnecessary.

Not opened an issue as this is such a minor PR, however can if required.
🦕