### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "artifactregistry",
     "name_pretty": "Artifact Registry",
     "product_documentation": "https://cloud.google.com/artifact-registry",
-    "client_documentation": "https://googleapis.dev/python/artifactregistry/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/artifactregistry/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ CI/CD tooling to set up automated pipelines.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-artifact-registry.svg
    :target: https://pypi.org/project/google-cloud-artifact-registry/
 .. _Artifact Registry: https://cloud.google.com/artifact-registry
-.. _Client Library Documentation: https://googleapis.dev/python/artifactregistry/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/artifactregistry/latest
 .. _Product Documentation:  https://cloud.google.com/artifact-registry
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.